### PR TITLE
Added clientside entities created by ClientsideModel to valid entity metatables

### DIFF
--- a/lua/dash/extensions/type.lua
+++ b/lua/dash/extensions/type.lua
@@ -13,6 +13,7 @@ local WEAPON 	= FindMetaTable 'Weapon'
 local NPC 		= FindMetaTable 'NPC'
 local NEXTBOT 	= FindMetaTable 'NextBot'
 local VEHICLE 	= FindMetaTable 'Vehicle'
+local CSENTITY	= FindMetaTable 'CSEnt'
 
 local entmts = {
 	[ENTITY] 	= true,
@@ -25,6 +26,8 @@ local entmts = {
 
 if (SERVER) then
 	entmts[NEXTBOT] = true
+else
+    entmts[CSENTITY] = true
 end
 
 function isstring(v)


### PR DESCRIPTION
While running down an issue when creating clientside entities via StarfallEx, I discovered that Dash's overriding of `isentity`/`IsEntity` was causing the issue.

Clientside entities (C_BaseFlex, CSEnt) are valid entities on a vanilla server as tested by
```lua
lua_run_cl local ent = ClientsideModel('error.mdl') print(ent, isentity(ent))
```

But with Dash they are considered invalid because their metatable wasn't included in `entmts`.