### PR TITLE
Fix hook.Remove being called in a hook breaking later hooks

### DIFF
--- a/lua/dash/extensions/type.lua
+++ b/lua/dash/extensions/type.lua
@@ -51,7 +51,7 @@ function ismaterial(v)
 end
 
 function isnumber(v)
-	return (v ~= nil) and (v == tonumber(v))
+	return (getmetatable(v) == nil) and (v ~= nil) and (v == tonumber(v))
 end
 
 function isbool(v)

--- a/lua/dash/libraries/hook.lua
+++ b/lua/dash/libraries/hook.lua
@@ -4,7 +4,7 @@ local isfunction 	= isfunction
 local IsValid 		= IsValid
 
 local hook_callbacks = {}
-local hook_mapping   = {}
+local hook_mapping   = {} -- Bidirectional mapping between indexes and ids (ids cannot be numbers)
 
 local function GetTable() -- This function is now slow
 	local ret = {}
@@ -131,6 +131,7 @@ local function Add(name, id, callback)
 	local mapping = hook_mapping[name]
 
 	if (not isstring(id)) then
+		assert(not isnumber(id))
 		local orig = callback
 		callback = function(...)
 			if IsValid(id) then

--- a/lua/dash/libraries/hook.lua
+++ b/lua/dash/libraries/hook.lua
@@ -90,7 +90,7 @@ local function Remove(name, id)
 			hook_callbacks[name] = nil
 		end
 	else
-		-- Replace it with a "gap function" - when it is called later, it will pop the last element off, call it, and replace itself
+		-- Replace it with a "gap function" - when it is called later, it will pop the last callback off, call it, and replace itself
 		callbacks[index] = function(...)
 			local count = callbacks[0]
 			assert(count > index)
@@ -122,13 +122,16 @@ local function Add(name, id, callback)
 		return
 	end
 
-	local callbacks = hook_callbacks[name]
+	local callbacks, mapping = hook_callbacks[name], hook_mapping[name]
 	if (callbacks == nil) then
 		callbacks = {[0] = 0}
-		hook_callbacks[name], hook_mapping[name] = callbacks, {}
-	end
+		hook_callbacks[name] = callbacks
 
-	local mapping = hook_mapping[name]
+		if (mapping == nil) then
+			mapping = {}
+			hook_mapping[name] = mapping
+		end
+	end
 
 	if (not isstring(id)) then
 		assert(not isnumber(id))


### PR DESCRIPTION
If you do code like:
```
hook.Add("Tick", "ThingToDoNextTick", function()
    print("Joker Gaming")
    hook.Remove("Tick", "ThingToDoNextTick")
end)
```

This would work in vanilla hooks because iterate-and-remove works with pairs(). But it does not work with this hook library because removing the hook causes the last hook in the sequence to be swapped into its place, then that previous last hook will be skipped by the iteration.

The fix makes hook.Remove put a temporary "gap function" where the removed hook used to be which will be swapped on the next call of the hook (it only does this if there are later hooks). The gap functions are denoted by the lack of an id being mapped to their index.

Code to test it: (output is wrong before change)
```
local calls, frame = 0, 0
for i=1, 100 do
    local n = "hook"..i
    hook.Add("Tick", n, function()
        if frame ~= engine.TickCount() then
            frame = engine.TickCount()
            calls = 0
        end
        calls = calls + 1
        hook.Remove("Tick", n)
    end)
end
timer.Simple(0.1, function() print("calls", calls) end)
```

Other changes:
- Combine hook_index and hook_id to one table
- Store #callbacks in callbacks[0] (this is way faster, #tab is O(logn))
- Skip the initial `i=i+1` in callback iteration (if this was intentional because of lua jit let me know, idk)
- Remove the table from hook_callbacks when the last hook is removed so its faster
- type.lua: Fix a big string being a slow edge case on isnumber()